### PR TITLE
Fixed imports in  "getting started" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ These examples show how to:
 - Store a wavetable as a wav file.
 
 ```python
-import wavetable
-import sig
-import dsp
+from osc_gen import wavetable
+from osc_gen import sig
+from osc_gen import dsp
 
 
 # Create a signal generator.


### PR DESCRIPTION
Just discovered this project, great work and exactly what I needed for some basic wavetable exploration for my Elektron Model:Samples. I noticed that in the "getting started" example in the README the import of the actual "osc_gen" module is missing, so here's a PR that fixes that. 